### PR TITLE
feat: Add i18n internationalization for workflow processing

### DIFF
--- a/web/app/components/workflow/run/node.tsx
+++ b/web/app/components/workflow/run/node.tsx
@@ -96,7 +96,7 @@ const NodePanel: FC<Props> = ({ nodeInfo, hideInfo = false }) => {
               <div className={cn('px-[10px] py-1', hideInfo && '!px-2 !py-0.5')}>
                 <CodeEditor
                   readOnly
-                  title={<div>INPUT</div>}
+                  title={<div>{t('workflow.common.input').toLocaleUpperCase()}</div>}
                   language={CodeLanguage.json}
                   value={nodeInfo.inputs}
                   isJSONStringifyBeauty
@@ -107,7 +107,7 @@ const NodePanel: FC<Props> = ({ nodeInfo, hideInfo = false }) => {
               <div className={cn('px-[10px] py-1', hideInfo && '!px-2 !py-0.5')}>
                 <CodeEditor
                   readOnly
-                  title={<div>PROCESS DATA</div>}
+                  title={<div>{t('workflow.common.processData').toLocaleUpperCase()}</div>}
                   language={CodeLanguage.json}
                   value={nodeInfo.process_data}
                   isJSONStringifyBeauty
@@ -118,7 +118,7 @@ const NodePanel: FC<Props> = ({ nodeInfo, hideInfo = false }) => {
               <div className={cn('px-[10px] py-1', hideInfo && '!px-2 !py-0.5')}>
                 <CodeEditor
                   readOnly
-                  title={<div>OUTPUT</div>}
+                  title={<div>{t('workflow.common.output').toLocaleUpperCase()}</div>}
                   language={CodeLanguage.json}
                   value={nodeInfo.outputs}
                   isJSONStringifyBeauty

--- a/web/app/components/workflow/run/result-panel.tsx
+++ b/web/app/components/workflow/run/result-panel.tsx
@@ -1,5 +1,6 @@
 'use client'
 import type { FC } from 'react'
+import { useTranslation } from 'react-i18next'
 import StatusPanel from './status'
 import MetaData from './meta'
 import CodeEditor from '@/app/components/workflow/nodes/_base/components/editor/code-editor'
@@ -33,6 +34,7 @@ const ResultPanel: FC<ResultPanelProps> = ({
   steps,
   showSteps,
 }) => {
+  const { t } = useTranslation()
   return (
     <div className='bg-white py-2'>
       <div className='px-4 py-2'>
@@ -46,7 +48,7 @@ const ResultPanel: FC<ResultPanelProps> = ({
       <div className='px-4 py-2 flex flex-col gap-2'>
         <CodeEditor
           readOnly
-          title={<div>INPUT</div>}
+          title={<div>{t('workflow.common.input').toLocaleUpperCase()}</div>}
           language={CodeLanguage.json}
           value={inputs}
           isJSONStringifyBeauty
@@ -54,7 +56,7 @@ const ResultPanel: FC<ResultPanelProps> = ({
         {process_data && (
           <CodeEditor
             readOnly
-            title={<div>PROCESS DATA</div>}
+            title={<div>{t('workflow.common.processData').toLocaleUpperCase()}</div>}
             language={CodeLanguage.json}
             value={process_data}
             isJSONStringifyBeauty
@@ -63,7 +65,7 @@ const ResultPanel: FC<ResultPanelProps> = ({
         {(outputs || status === 'running') && (
           <CodeEditor
             readOnly
-            title={<div>OUTPUT</div>}
+            title={<div>{t('workflow.common.output').toLocaleUpperCase()}</div>}
             language={CodeLanguage.json}
             value={outputs}
             isJSONStringifyBeauty

--- a/web/i18n/en-US/workflow.ts
+++ b/web/i18n/en-US/workflow.ts
@@ -46,6 +46,9 @@ const translation = {
       content: 'The variable is used in other nodes. Do you still want to remove it?',
     },
     insertVarTip: 'Press the \'/\' key to insert quickly',
+    processData: 'Process Data',
+    input: 'Input',
+    output: 'Output',
   },
   errorMsg: {
     fieldRequired: '{{field}} is required',

--- a/web/i18n/fr-FR/workflow.ts
+++ b/web/i18n/fr-FR/workflow.ts
@@ -46,6 +46,9 @@ const translation = {
       content: 'La variable est utilisée dans d\'autres nœuds. Voulez-vous toujours la supprimer ?',
     },
     insertVarTip: 'Appuyez sur la touche \'/\' pour insérer rapidement',
+    processData: 'Traiter les données',
+    input: 'Entrée',
+    output: 'Sortie',
   },
   errorMsg: {
     fieldRequired: '{{field}} est requis',

--- a/web/i18n/ja-JP/workflow.ts
+++ b/web/i18n/ja-JP/workflow.ts
@@ -46,6 +46,9 @@ const translation = {
       content: '他のノードで変数が使用されています。それでも削除しますか？',
     },
     insertVarTip: 'クイック挿入のために\'/\'キーを押します',
+    processData: '処理データ',
+    input: '入力',
+    output: '出力',
   },
   errorMsg: {
     fieldRequired: '{{field}}は必須です',

--- a/web/i18n/pt-BR/workflow.ts
+++ b/web/i18n/pt-BR/workflow.ts
@@ -46,6 +46,9 @@ const translation = {
       content: 'A variável está sendo usada em outros nós. Deseja removê-la mesmo assim?',
     },
     insertVarTip: 'Pressione a tecla \'/\' para inserir rapidamente',
+    processData: 'Processar dados',
+    input: 'Entrada',
+    output: 'Saída',
   },
   errorMsg: {
     fieldRequired: '{{field}} é obrigatório',

--- a/web/i18n/uk-UA/workflow.ts
+++ b/web/i18n/uk-UA/workflow.ts
@@ -46,6 +46,9 @@ const translation = {
       content: 'Цю змінну використовується в інших вузлах. Ви все ще хочете її видалити?',
     },
     insertVarTip: 'Натисніть клавішу "/" для швидкого вставлення',
+    processData: 'Обробка даних',
+    input: 'Вхід',
+    output: 'Вихід',
   },
   errorMsg: {
     fieldRequired: '{{field}} є обов\'язковим',

--- a/web/i18n/vi-VN/workflow.ts
+++ b/web/i18n/vi-VN/workflow.ts
@@ -46,6 +46,9 @@ const translation = {
       content: 'Biến được sử dụng trong các nút khác. Bạn vẫn muốn xóa nó?',
     },
     insertVarTip: 'Nhấn phím \'/\' để chèn nhanh',
+    processData: 'Xử lý dữ liệu',
+    input: 'Nhập',
+    output: 'Đầu ra',
   },
   errorMsg: {
     fieldRequired: '{{field}} là bắt buộc',

--- a/web/i18n/zh-Hans/workflow.ts
+++ b/web/i18n/zh-Hans/workflow.ts
@@ -46,6 +46,9 @@ const translation = {
       content: '该变量在其他节点中使用。您是否仍要删除它？',
     },
     insertVarTip: '按 \'/\' 键快速插入',
+    processData: '数据处理',
+    input: '输入',
+    output: '输出',
   },
   errorMsg: {
     fieldRequired: '{{field}} 不能为空',


### PR DESCRIPTION
# Description

Extract translatable strings for input, process data, and output labels in the workflow processing code
Use the t function from the i18n library to dynamically load translations for the labels
Update the CodeEditor components to display the translated labels in the titles
Ensure that the translations are loaded correctly based on the user's language preference



Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [🙆 ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

sure！ 

- [ ] TODO

# Suggested Checklist:

- [🙆 ] I have performed a self-review of my own code
- [🙆 ] I have commented my code, particularly in hard-to-understand areas
- [🙆 ] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
