### PR TITLE
feat: use Taobao registry for Yarn installs in China

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -16,6 +16,11 @@ COPY yarn.lock .
 RUN --mount=type=cache,target=/root/.yarn YARN_CACHE_FOLDER=/root/.yarn \
     yarn install --frozen-lockfile
 
+# if you located in China, you can use taobao registry to speed up
+# RUN --mount=type=cache,target=/root/.yarn YARN_CACHE_FOLDER=/root/.yarn \
+#     yarn install --frozen-lockfile --registry https://registry.npm.taobao.org/
+
+
 
 # build resources
 FROM base as builder


### PR DESCRIPTION


# Description

Utilize the Taobao npm registry mirror for Yarn package installations in Docker builds to accelerate the installation process for users in China. Implemented caching for Yarn to reuse packages between builds, improving build speed and efficiency.


Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] TODO

# Suggested Checklist:

- [🙆 ] I have performed a self-review of my own code
- [🙆 ] I have commented my code, particularly in hard-to-understand areas
- [ 🙆] My changes generate no new warnings
- [ 🙆] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ ] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
